### PR TITLE
Feat/add network

### DIFF
--- a/packages/extension-koni-base/src/api/dotsama/api-helper/spec/astar_evm.ts
+++ b/packages/extension-koni-base/src/api/dotsama/api-helper/spec/astar_evm.ts
@@ -1,0 +1,42 @@
+// Copyright 2017-2022 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      // on all versions
+      minmax: [0, undefined],
+      types: {
+        Keys: 'AccountId',
+        Address: 'MultiAddress',
+        LookupSource: 'MultiAddress',
+        AmountOf: 'Amount',
+        Amount: 'i128',
+        SmartContract: {
+          _enum: {
+            Evm: 'H160',
+            Wasm: 'AccountId'
+          }
+        },
+        EraStakingPoints: {
+          total: 'Balance',
+          stakers: 'BTreeMap<AccountId, Balance>',
+          formerStakedEra: 'EraIndex',
+          claimedRewards: 'Balance'
+        },
+        EraRewardAndStake: {
+          rewards: 'Balance',
+          staked: 'Balance'
+        },
+        EraIndex: 'u32'
+      }
+    }
+  ]
+};
+
+export default definitions;

--- a/packages/extension-koni-base/src/api/dotsama/api-helper/spec/index.ts
+++ b/packages/extension-koni-base/src/api/dotsama/api-helper/spec/index.ts
@@ -3,13 +3,19 @@
 
 import type { OverrideBundleDefinition } from '@polkadot/types/types';
 
+import astar from './astar';
+import astar_evm from './astar_evm';
+import shiden from './shiden';
+import shiden_evm from './shiden_evm';
+import shibuya from './shibuya';
+import shibuya_evm from './shibuya_evm';
+
 import acala from './acala';
 import ajuna from './ajuna';
 import altair from './altair';
 import apron from './apron';
 import aresGladios from './ares-gladios';
 import aresParachain from './ares-parachain';
-import astar from './astar';
 import automata from './automata';
 import basilisk from './basilisk';
 import beresheet from './beresheet';
@@ -93,8 +99,6 @@ import quartz from './quartz';
 import realis from './realis';
 import riochain from './riochain';
 import robonomics from './robonomics';
-import shibuya from './shibuya';
-import shiden from './shiden';
 import snowbridge from './snowbridge';
 import soraSubstrate from './soraSubstrate';
 import spanner from './spanner';
@@ -123,6 +127,13 @@ import zero from './zero';
 
 // NOTE: The mapping is done from specName in state.getRuntimeVersion
 const spec: Record<string, OverrideBundleDefinition> = {
+  astar,
+  astar_evm,
+  shiden,
+  shiden_evm,
+  shibuya,
+  shibuya_evm,
+
   Crab: crab,
   Darwinia: darwinia,
   'Darwinia Crab PC2': pangolin,
@@ -141,7 +152,6 @@ const spec: Record<string, OverrideBundleDefinition> = {
   'ares-mars': aresParachain,
   'ares-odyssey': aresParachain,
   asgard: bifrostAsgard,
-  astar,
   automata: automata,
   basilisk,
   beresheet,
@@ -236,8 +246,6 @@ const spec: Record<string, OverrideBundleDefinition> = {
   realis,
   'riochain-runtime': riochain,
   robonomics,
-  shibuya,
-  shiden,
   snowbridge,
   'sora-substrate': soraSubstrate,
   sora_ksm: soraSubstrate,

--- a/packages/extension-koni-base/src/api/dotsama/api-helper/spec/shibuya_evm.ts
+++ b/packages/extension-koni-base/src/api/dotsama/api-helper/spec/shibuya_evm.ts
@@ -1,0 +1,52 @@
+// Copyright 2017-2022 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      // on all versions
+      minmax: [0, undefined],
+      types: {
+        Keys: 'AccountId',
+        Address: 'MultiAddress',
+        LookupSource: 'MultiAddress',
+        AmountOf: 'Amount',
+        Amount: 'i128',
+        SmartContract: {
+          _enum: {
+            Evm: 'H160',
+            Wasm: 'AccountId'
+          }
+        },
+        EraStakingPoints: {
+          total: 'Balance',
+          stakers: 'BTreeMap<AccountId, Balance>',
+          formerStakedEra: 'EraIndex',
+          claimedRewards: 'Balance'
+        },
+        PalletDappsStakingEraStakingPoints: {
+          total: 'Balance',
+          stakers: 'BTreeMap<AccountId, Balance>',
+          formerStakedEra: 'EraIndex',
+          claimedRewards: 'Balance'
+        },
+        EraRewardAndStake: {
+          rewards: 'Balance',
+          staked: 'Balance'
+        },
+        PalletDappsStakingEraRewardAndStake: {
+          rewards: 'Balance',
+          staked: 'Balance'
+        },
+        EraIndex: 'u32'
+      }
+    }
+  ]
+};
+
+export default definitions;

--- a/packages/extension-koni-base/src/api/dotsama/api-helper/spec/shiden_evm.ts
+++ b/packages/extension-koni-base/src/api/dotsama/api-helper/spec/shiden_evm.ts
@@ -1,0 +1,52 @@
+// Copyright 2017-2022 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      // on all versions
+      minmax: [0, undefined],
+      types: {
+        Keys: 'AccountId',
+        Address: 'MultiAddress',
+        LookupSource: 'MultiAddress',
+        AmountOf: 'Amount',
+        Amount: 'i128',
+        SmartContract: {
+          _enum: {
+            Evm: 'H160',
+            Wasm: 'AccountId'
+          }
+        },
+        EraStakingPoints: {
+          total: 'Balance',
+          stakers: 'BTreeMap<AccountId, Balance>',
+          formerStakedEra: 'EraIndex',
+          claimedRewards: 'Balance'
+        },
+        PalletDappsStakingEraStakingPoints: {
+          total: 'Balance',
+          stakers: 'BTreeMap<AccountId, Balance>',
+          formerStakedEra: 'EraIndex',
+          claimedRewards: 'Balance'
+        },
+        EraRewardAndStake: {
+          rewards: 'Balance',
+          staked: 'Balance'
+        },
+        PalletDappsStakingEraRewardAndStake: {
+          rewards: 'Balance',
+          staked: 'Balance'
+        },
+        EraIndex: 'u32'
+      }
+    }
+  ]
+};
+
+export default definitions;

--- a/packages/extension-koni-base/src/api/dotsama/balance.ts
+++ b/packages/extension-koni-base/src/api/dotsama/balance.ts
@@ -15,6 +15,38 @@ import { categoryAddresses, sumBN } from '@polkadot/extension-koni-base/utils/ut
 import { AccountInfo } from '@polkadot/types/interfaces';
 import { BN } from '@polkadot/util';
 
+import Web3 from 'web3';
+import { u8aToHex } from '@polkadot/util';
+import { addressToEvm } from '@polkadot/util-crypto';
+
+async function getBalanceAstarEvm(networkKey: string) {
+  //let address: string = '0x13622064f9722AF46F29B6f6ee8C7483d85ed365';
+  //let address: string = '0x96cbef157358b7c90b0481ba8b3db8f58e014116';
+  let wssURL = '';
+  if (networkKey === 'astarEvm') {
+    wssURL = 'wss://rpc.astar.network';
+  } else if (networkKey === 'shidenEvm') {
+    wssURL = 'wss://rpc.shiden.astar.network';
+  } else if (networkKey === 'shibuyaEvm') {
+    wssURL = 'wss://rpc.shibuya.astar.network';
+  }
+  let ss58Address: string = 'ZM24FujhBK3XaDsdkpYBf4QQAvRkoMq42aqrUQnxFo3qrAw';
+  let address = u8aToHex(addressToEvm(ss58Address));
+  const web3 = new Web3(new Web3.providers.WebsocketProvider(wssURL));
+  const balance = await web3.eth.getBalance(address);
+  console.log('Arth await balance: ' + networkKey + ', SS58:' + ss58Address + ' -> H160:' + address + ', ' + balance);
+
+  //  const transaction = await api.value.tx.evm.withdraw(address, 1);
+  //  if (!transaction) {
+  //    throw Error('Cannot withdraw the deposit');
+  //  }
+
+  //return balance;
+}
+getBalanceAstarEvm('astarEvm');
+getBalanceAstarEvm('shibuyaEvm');
+  
+
 function subscribeWithDerive (addresses: string[], networkKey: string, networkAPI: ApiProps, callback: (networkKey: string, rs: BalanceItem) => void) {
   const freeMap: Record<string, BN> = {};
   const reservedMap: Record<string, BN> = {};

--- a/packages/extension-koni-base/src/api/endpoints.ts
+++ b/packages/extension-koni-base/src/api/endpoints.ts
@@ -74,6 +74,60 @@ const NETWORKS: Record<string, NetWorkInfo> = {
     crowdloanUrl: 'https://crowdloan.astar.network/#/',
     decimals: 18
   },
+  astar_evm: {
+    chain: 'Astar',
+    genesisHash: '0x9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6',
+    ss58Format: 5,
+    provider: 'wss://astar.api.onfinality.io/public-ws',
+    groups: ['POLKADOT_PARACHAIN'],
+    paraId: 2006,
+    isEthereum: true,
+    nativeToken: 'ASTR',
+    crowdloanUrl: 'https://crowdloan.astar.network/#/',
+    decimals: 18
+  },
+  shiden: {
+    chain: 'Shiden',
+    genesisHash: '0xf1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108',
+    ss58Format: 5,
+    provider: 'wss://shiden.api.onfinality.io/public-ws',
+    groups: ['KUSAMA_PARACHAIN'],
+    paraId: 2007,
+    nativeToken: 'SDN',
+    crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
+  },
+  shiden_evm: {
+    chain: 'Shiden',
+    genesisHash: '0xf1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108',
+    ss58Format: 5,
+    provider: 'wss://shiden.api.onfinality.io/public-ws',
+    groups: ['KUSAMA_PARACHAIN'],
+    paraId: 2007,
+    isEthereum: true,
+    nativeToken: 'SDN',
+    crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
+  },
+  shibuya: {
+    chain: 'Shibuya',
+    genesisHash: '0xddb89973361a170839f80f152d2e9e38a376a5a7eccefcade763f46a8e567019',
+    ss58Format: 5,
+    provider: 'wss://rpc.shibuya.astar.network',
+    groups: ['KUSAMA_PARACHAIN'],
+    paraId: 2007,
+    nativeToken: 'SDN',
+    crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
+  },
+  shibuya_evm: {
+    chain: 'Shibuya',
+    genesisHash: '0xddb89973361a170839f80f152d2e9e38a376a5a7eccefcade763f46a8e567019',
+    ss58Format: 5,
+    provider: 'wss://rpc.shibuya.astar.network',
+    groups: ['KUSAMA_PARACHAIN'],
+    paraId: 2007,
+    isEthereum: true,
+    nativeToken: 'SDN',
+    crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
+  },
 
 
   acala: {
@@ -359,16 +413,6 @@ const NETWORKS: Record<string, NetWorkInfo> = {
     paraId: 2023,
     isEthereum: true,
     nativeToken: 'MOVR',
-    crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
-  },
-  shiden: {
-    chain: 'Shiden',
-    genesisHash: '0xf1cf9022c7ebb34b162d5b5e34e705a5a740b2d0ecc1009fb89023e62a488108',
-    ss58Format: 5,
-    provider: 'wss://shiden.api.onfinality.io/public-ws',
-    groups: ['KUSAMA_PARACHAIN'],
-    paraId: 2007,
-    nativeToken: 'SDN',
     crowdloanUrl: 'https://polkadot.js.org/apps/#/parachains/crowdloan'
   },
   khala: {

--- a/packages/extension-koni-base/src/api/endpoints.ts
+++ b/packages/extension-koni-base/src/api/endpoints.ts
@@ -61,6 +61,21 @@ const NETWORKS: Record<string, NetWorkInfo> = {
     paraId: 1000,
     nativeToken: 'KSM'
   },
+
+
+  astar: {
+    chain: 'Astar',
+    genesisHash: '0x9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6',
+    ss58Format: 5,
+    provider: 'wss://astar.api.onfinality.io/public-ws',
+    groups: ['POLKADOT_PARACHAIN'],
+    paraId: 2006,
+    nativeToken: 'ASTR',
+    crowdloanUrl: 'https://crowdloan.astar.network/#/',
+    decimals: 18
+  },
+
+
   acala: {
     chain: 'Acala',
     genesisHash: '0xfc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c',
@@ -81,17 +96,6 @@ const NETWORKS: Record<string, NetWorkInfo> = {
     isEthereum: true,
     nativeToken: 'GLMR',
     crowdloanUrl: 'https://moonbeam.foundation/moonbeam-crowdloan/',
-    decimals: 18
-  },
-  astar: {
-    chain: 'Astar',
-    genesisHash: '0x9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6',
-    ss58Format: 5,
-    provider: 'wss://astar.api.onfinality.io/public-ws',
-    groups: ['POLKADOT_PARACHAIN'],
-    paraId: 2006,
-    nativeToken: 'ASTR',
-    crowdloanUrl: 'https://crowdloan.astar.network/#/',
     decimals: 18
   },
   parallel: {

--- a/packages/extension-koni-base/src/api/subquery/history.ts
+++ b/packages/extension-koni-base/src/api/subquery/history.ts
@@ -15,6 +15,13 @@ import { state } from '@polkadot/extension-koni-base/background/handlers';
 import { isAccountAll, reformatAddress } from '@polkadot/extension-koni-base/utils/utils';
 
 export const HistoryApiMap: Record<string, string> = {
+  astar: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-astar',
+  astar_evm: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-astar',
+  shiden: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-shiden',
+  shiden_evm: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-shiden',
+  shibuya: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-shibuya',
+  shibuya_evm: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-shibuya',
+
   polkadot: 'https://api.subquery.network/sq/nova-wallet/nova-westend',
   kusama: 'https://api.subquery.network/sq/nova-wallet/nova-kusama',
   westend: 'https://api.subquery.network/sq/nova-wallet/nova-westend',
@@ -26,7 +33,6 @@ export const HistoryApiMap: Record<string, string> = {
   clover: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-clover',
   basilisk: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-basilisk',
   acala: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-acala',
-  astar: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-astar',
   karura: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-karura',
   altair: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-altair',
   kilt: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-kilt',
@@ -34,7 +40,6 @@ export const HistoryApiMap: Record<string, string> = {
   statemint: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-statemint',
   quartz: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-quartz',
   zeigeist: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist',
-  shiden: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-shiden',
   statemine: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-statemine',
   moonbeam: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-moonbeam',
   moonriver: 'https://api.subquery.network/sq/nova-wallet/nova-wallet-moonriver',

--- a/packages/extension-koni-ui/src/assets/logo/index.ts
+++ b/packages/extension-koni-ui/src/assets/logo/index.ts
@@ -3,6 +3,16 @@
 
 const LogosMap: Record<string, string> = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  astar: require('./astar.png'),
+  astar_evm: require('./astar.png'),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  shiden: require('./shiden.png'),
+  shiden_evm: require('./shiden.png'),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  shibuya: require('./astar.png'),
+  shibuya_evm: require('./astar.png'),
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   acala: require('./acala.svg'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   ausd: require('./ausd.svg'),
@@ -14,8 +24,6 @@ const LogosMap: Record<string, string> = {
   lcdot: require('./lcdot.svg'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   altair: require('./altair.svg'),
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  astar: require('./astar.png'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   basilisk: require('./basilisk.png'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -94,8 +102,6 @@ const LogosMap: Record<string, string> = {
   sakura: require('./sakura.svg'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   shadow: require('./shadow.svg'),
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  shiden: require('./shiden.png'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   'sora-substrate': require('./sora-substrate.svg'),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/extension-koni-ui/src/util/chainBalancesApi.tsx
+++ b/packages/extension-koni-ui/src/util/chainBalancesApi.tsx
@@ -9,9 +9,15 @@ import { isEmptyArray } from '@polkadot/extension-koni-ui/util/common';
 import { AccountInfoItem, BalanceInfo, BalanceSubInfo } from './types';
 
 export const priceParamByNetworkKeyMap: Record<string, string> = {
+  astar: 'astar',
+  astar_evm: 'astar_evm',
+  shiden: 'shiden',
+  shiden_evm: 'shiden_evm',
+  shibuya: 'shibuya',
+  shibuya_evm: 'shibuya_evm',
+
   acala: 'acala',
   // 'altair':'altair',
-  astar: 'astar',
   // 'basilisk': 'basilisk',
   bifrost: 'bifrost-native-coin',
   calamari: 'calamari-network',
@@ -52,7 +58,6 @@ export const priceParamByNetworkKeyMap: Record<string, string> = {
   // 'rococo':'rococo',
   sakura: 'sakura',
   shadow: 'crust-storage-market',
-  shiden: 'shiden',
   'sora-substrate': 'sora',
   statemine: 'statemine',
   statemint: 'statemint',

--- a/packages/extension-koni-ui/src/util/index.ts
+++ b/packages/extension-koni-ui/src/util/index.ts
@@ -133,9 +133,15 @@ export function getLogoByNetworkKey (networkKey: string, defaultLogo = 'default'
 }
 
 export const subscanByNetworkKey: Record<string, string> = {
+  astar: 'https://astar.subscan.io',
+  astar_evm: 'https://astar.subscan.io',
+  shiden: 'https://shiden.subscan.io',
+  shiden_evm: 'https://shiden.subscan.io',
+  shibuya: 'https://shibuya.subscan.io',
+  shibuya_evm: 'https://shibuya.subscan.io',
+
   acala: 'https://acala.subscan.io',
   // 'altair': 'https://altair.subscan.io',
-  astar: 'https://astar.subscan.io',
   // 'basilisk': 'https://basilisk.subscan.io',
   bifrost: 'https://bifrost.subscan.io',
   calamari: 'https://calamari.subscan.io',
@@ -171,7 +177,6 @@ export const subscanByNetworkKey: Record<string, string> = {
   quartz: 'https://quartz.subscan.io',
   sakura: 'https://sakura.subscan.io',
   // 'shadow': 'https://shadow.subscan.io',
-  shiden: 'https://shiden.subscan.io',
   sora: 'https://sora.subscan.io',
   statemine: 'https://statemine.subscan.io',
   subgame: 'https://subgame.subscan.io',


### PR DESCRIPTION
Add networks astar_evm, shiden_evm, shibuya, shibuya_evm

endpointsにて例えば astar,  astar_evm と分けて作り込むか、
例えば、isEthereum みたいなパラメータを増やして(isMultiNativeEVM的な？ のと rpcProviderみたいなのを足す？)、networkKeyは増やさない方向に行くか、検討は必要に思われます。









